### PR TITLE
Added setup.py with requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@
 *.swp
 trial.py
 *.txt
-setup.py
 dist
 *.egg-info

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-dateutil
+requests

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,9 @@ setup(
     author_email = 'rohan.bavishi95@gmail.com',
     url = 'https://github.com/rbavishi/Habitican-Curse',
     license = 'MIT',
-    scripts = ['habitican-curse']
+    scripts = ['habitican-curse'],
+    install_requires=[
+        'python-dateutil',
+        'requests',
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup
+
+setup(
+    name = 'habitican_curse',
+    packages = ['habitican_curse'],
+    version = '2.1.3',
+    description = 'Linux Terminal Application for Habitica',
+    author = 'Rohan Bavishi',
+    author_email = 'rohan.bavishi95@gmail.com',
+    url = 'https://github.com/rbavishi/Habitican-Curse',
+    license = 'MIT',
+    scripts = ['habitican-curse']
+)


### PR DESCRIPTION
I have added a `setup.py` file (taken from the tarball download on PyPI) that lists the package's dependencies (`python-dateutil` and `requests`).  Including the list of required packages is necessary in order for Habitican-Curse to be installed properly, and having a `setup.py` file is highly, highly recommended; see the [Python Packaging User Guide](https://python-packaging-user-guide.readthedocs.org/en/latest/) (in particular [the section on `setup.py`](https://python-packaging-user-guide.readthedocs.org/en/latest/distributing/#setup-py)) for more information.
